### PR TITLE
Add Planet to Tests

### DIFF
--- a/ci/Selenium/README.md
+++ b/ci/Selenium/README.md
@@ -12,7 +12,9 @@ To run the tests locally, perform the following steps:
 * Set up the following variables in your environment:
   * `bf_password` The Disadvantaged user account password to use
   * `bf_username` The Disadvantaged user account name to use
-  * `bf_url` The URL of beachfront to test. 
+  * `bf_url` The URL of beachfront to test.
+  * `planet_key` Optional. The API Key used for testing the Planet data sources.
+  * `planet_location` Required only if the `planet_key` is specified. Required for setting the valid Planet locations for the key. 
 * From this `bftest-integration/ci/Selenium/` directory, run `mvn clean test` to run the tests. These tests will take a few minutes. 
 
 # JenkinsFile

--- a/ci/Selenium/src/test/java/bfui/test/TestAuthentication.java
+++ b/ci/Selenium/src/test/java/bfui/test/TestAuthentication.java
@@ -52,7 +52,7 @@ public class TestAuthentication {
 
 	@Test
 	@Info(importance = Importance.MEDIUM)
-	public void url_jack_login() throws Exception {
+	public void urlJackLogin() throws Exception {
 		// Insert the logged_in param before actually logging in
 		driver.get(BASE_URL + "?logged_in=true");
 		// Jobs should fail to display due to not being clickable
@@ -61,7 +61,7 @@ public class TestAuthentication {
 
 	@Test(expected = WebDriverException.class)
 	@Info(importance = Importance.MEDIUM)
-	public void click_behind_login() throws Exception {
+	public void clickBehindLogin() throws Exception {
 		// Try to click a button without being logged in.
 		mainPage.navigateJobsPage();
 		assertFalse("No interaction with map before login", mainPage.getCurrentURL().contains("job"));
@@ -69,7 +69,7 @@ public class TestAuthentication {
 
 	@Test
 	@Info(importance = Importance.HIGH)
-	public void standard_login_logout() throws InterruptedException {
+	public void standardLoginLogout() throws InterruptedException {
 		// Check that the consent banner is present and contains "Consent".
 		assertTrue("Consent banner should contain 'consent' text", mainPage.getConsentBannerText().toUpperCase().contains("CONSENT"));
 		// Login via Disadvantaged

--- a/ci/Selenium/src/test/java/bfui/test/TestCreateJob.java
+++ b/ci/Selenium/src/test/java/bfui/test/TestCreateJob.java
@@ -68,21 +68,21 @@ public class TestCreateJob {
 
 	@Test
 	@Info(importance = Importance.HIGH)
-	public void landsat_job_with_mask() throws Exception {
+	public void landsatJobWithMask() throws Exception {
 		// Local Landsat8 job, mask enabled
 		createJobFullTest("landsat_pds", null, true);
 	}
 
 	@Test
 	@Info(importance = Importance.HIGH)
-	public void landsat_job_no_mask() throws Exception {
+	public void landsatJobNoMask() throws Exception {
 		// Local Landsat8 job, no mask
 		createJobFullTest("landsat_pds", null, false);
 	}
 
 	@Test
 	@Info(importance = Importance.HIGH)
-	public void planet_landsat_job() throws Exception {
+	public void planetLandsatJob() throws Exception {
 		// Planet Landsat Job, no mask
 		if (PLANET_KEY != null) {
 			zoomToLocation(PLANET_LOCATION);
@@ -94,7 +94,7 @@ public class TestCreateJob {
 
 	@Test
 	@Info(importance = Importance.HIGH)
-	public void planet_scope_job() throws Exception {
+	public void planetScopeJob() throws Exception {
 		// PlanetScope Job, no mask
 		if (PLANET_KEY != null) {
 			zoomToLocation(PLANET_LOCATION);
@@ -106,7 +106,7 @@ public class TestCreateJob {
 
 	@Test
 	@Info(importance = Importance.HIGH)
-	public void planet_rapideye_job() throws Exception {
+	public void planetRapidEyeJob() throws Exception {
 		// Planet RapidEye Job, no mask
 		if (PLANET_KEY != null) {
 			zoomToLocation(PLANET_LOCATION);

--- a/ci/Selenium/src/test/java/bfui/test/TestCreateJob.java
+++ b/ci/Selenium/src/test/java/bfui/test/TestCreateJob.java
@@ -180,7 +180,12 @@ public class TestCreateJob {
 		// Search for images:
 		createJobPage.searchForImagery();
 		assertTrue("Search is performing", createJobPage.isSearching());
-		createJobPage.waitForSearchToComplete();
+		try {
+			createJobPage.waitForSearchToComplete();
+		} catch (TimeoutException timeoutException) {
+			throw new TimeoutException(String.format("Search imagery for %s failed to complete. It has likely timed out.", source),
+					timeoutException);
+		}
 
 		// Click on a random result in the results table
 		createJobPage.selectRandomJobResult();

--- a/ci/Selenium/src/test/java/bfui/test/TestCreateJob.java
+++ b/ci/Selenium/src/test/java/bfui/test/TestCreateJob.java
@@ -134,8 +134,8 @@ public class TestCreateJob {
 		try {
 			// Waiting for the job to complete
 			statusPage.scrollIntoView();
-			String status = statusPage.getStatusOnCompletion(5 * 60);
-			assertTrue("Job has completed successfully", "Success".equals(status));
+			String status = statusPage.getStatusOnCompletion(8 * 60);
+			assertTrue(String.format("Job must complete successfully: %s", status), "Success".equals(status));
 			// Test Map Interaction
 			statusPage.zoomTo();
 			// Download tests
@@ -164,8 +164,8 @@ public class TestCreateJob {
 		assertTrue("Instruction text initially displayed", createJobPage.isInstructionTextVisible());
 
 		// Perform a bounding box search for imagery and submit
-		Point start = new Point(500, 600);
-		Point end = new Point(100, 100);
+		Point start = new Point(400, 500);
+		Point end = new Point(300, 300);
 		mainPage.drawBoundingBox(start, end);
 		assertTrue("Minimap displays on bounding box draw", createJobPage.isMinimapDisplayed());
 

--- a/ci/Selenium/src/test/java/bfui/test/TestMap.java
+++ b/ci/Selenium/src/test/java/bfui/test/TestMap.java
@@ -70,7 +70,7 @@ public class TestMap {
 
 	@Test
 	@Info(importance = Importance.HIGH)
-	public void enter_coords() throws Exception {
+	public void enterCoords() throws Exception {
 		// Check that the Coordinate Search window works with coordinates in lat, lon notation.
 
 		// Jump to Sri Lanka
@@ -91,7 +91,7 @@ public class TestMap {
 
 	@Test
 	@Info(importance = Importance.MEDIUM)
-	public void enter_decimal_coords() throws InterruptedException {
+	public void enterDecimalCoords() throws InterruptedException {
 		// These antimeridian jumps are converted to have digits after the decimal point.
 
 		// Jump to +AntiMeridian
@@ -107,7 +107,7 @@ public class TestMap {
 
 	@Test
 	@Info(importance = Importance.MEDIUM)
-	public void enter_DMS_Coords() throws Exception {
+	public void enterDMSCoords() throws Exception {
 		// Check that the "Jump To" window works with coordinates in DMS notation.
 
 		// Jump to Sri Lanka
@@ -138,7 +138,7 @@ public class TestMap {
 
 	@Test
 	@Info(importance = Importance.MEDIUM)
-	public void enter_UTM() throws InterruptedException {
+	public void enterUTM() throws InterruptedException {
 		// Check that the "Jump To" window works with coordinates in UTM notation.
 
 		// Jump to Sri Lanka
@@ -159,7 +159,7 @@ public class TestMap {
 
 	@Test
 	@Info(importance = Importance.MEDIUM)
-	public void enter_MGRS() throws InterruptedException {
+	public void enterMGRS() throws InterruptedException {
 		// Check that the "Jump To" window works with coordinates in MGRS notation.
 
 		// Jump to Sri Lanka
@@ -180,7 +180,7 @@ public class TestMap {
 
 	@Test
 	@Info(importance = Importance.LOW)
-	public void invalid_coords_entered() throws Exception {
+	public void invalidCoordsEntered() throws Exception {
 		// Open Search Window:
 		CoordinateSearchPage searchPage = mainPage.openCoordinateSearchDialog();
 
@@ -225,7 +225,7 @@ public class TestMap {
 	@Info(importance = Importance.LOW)
 	@Ignore // This test is being ignored because the OL behavior is just too unpredictable, and this test is of far too
 			// little value to deal with the constant side-effects and failures that it seems to cause.
-	public void zoom_buttons() throws InterruptedException {
+	public void zoomButtons() throws InterruptedException {
 		double originalZoom, newZoom;
 		// Reset the zoom to the middle and get the initial value
 		mainPage.setZoomSliderMiddle();
@@ -250,7 +250,7 @@ public class TestMap {
 
 	@Test
 	@Info(importance = Importance.LOW)
-	public void zoom_slider() throws InterruptedException {
+	public void zoomSlider() throws InterruptedException {
 		double originalZoom, newZoom;
 		// Set zoom slider to the middle
 		mainPage.setZoomSliderMiddle();
@@ -269,7 +269,7 @@ public class TestMap {
 
 	@Test
 	@Info(importance = Importance.MEDIUM)
-	public void banner_positions() {
+	public void bannerPositions() {
 		assertEquals("There should be 2 banners", 2, mainPage.getBannerCount());
 		assertEquals("Top banner should be the top of the window", 0, mainPage.getTopBannerPosition());
 		assertEquals("Bottom banner should be the bottom of the window", Utils.getWindowInnerHeight(driver), mainPage.getBottomBannerPos());
@@ -277,7 +277,7 @@ public class TestMap {
 
 	@Test
 	@Info(importance = Importance.LOW)
-	public void measure_tool() throws InterruptedException {
+	public void measureTool() throws InterruptedException {
 		// Activate the tool and set to meters
 		MeasureToolPage measurePage = mainPage.activateMeasureTool();
 		measurePage.selectUnits("meters");
@@ -299,7 +299,7 @@ public class TestMap {
 
 	@Test
 	@Info(importance = Importance.LOW)
-	public void open_close_measure_tool() {
+	public void openCloseMeasureTool() {
 		// Open and close the Measuring tool
 		MeasureToolPage measurePage = mainPage.activateMeasureTool();
 		measurePage.close();

--- a/ci/Selenium/src/test/java/bfui/test/page/CoordinateSearchPage.java
+++ b/ci/Selenium/src/test/java/bfui/test/page/CoordinateSearchPage.java
@@ -30,7 +30,7 @@ public class CoordinateSearchPage extends PageObject {
 	 * @param coordinates
 	 *            Free-form coordinate String
 	 */
-	public void search(String coordinates) throws InterruptedException {
+	public void search(String coordinates) {
 		entry.clear();
 		entry.sendKeys(coordinates);
 		new Actions(driver).click(submitButton).pause(500).build().perform(); // Wait for map animation
@@ -42,9 +42,6 @@ public class CoordinateSearchPage extends PageObject {
 	 * @return True if error is displayed, false if not
 	 */
 	public boolean isErrorVisible() {
-		// // Give a small period of time until the window is displayed
-		// WebDriverWait wait = new WebDriverWait(driver, (long) 0.25);
-		// wait.until(ExpectedConditions.visibilityOf(errorMessage));
 		return errorMessage.isDisplayed();
 	}
 
@@ -56,7 +53,7 @@ public class CoordinateSearchPage extends PageObject {
 	 * @param point
 	 *            The coordinates. lat=y, lon=x
 	 */
-	public void search(Point2D.Double point) throws InterruptedException {
+	public void search(Point2D.Double point) {
 		search(point.y, point.x);
 	}
 
@@ -70,7 +67,7 @@ public class CoordinateSearchPage extends PageObject {
 	 * @param lon
 	 *            Longitude
 	 */
-	public void search(double lat, double lon) throws InterruptedException {
+	public void search(double lat, double lon) {
 		search(Double.toString(lat) + ", " + Double.toString(lon));
 	}
 }

--- a/ci/Selenium/src/test/java/bfui/test/page/CreateJobPage.java
+++ b/ci/Selenium/src/test/java/bfui/test/page/CreateJobPage.java
@@ -24,19 +24,20 @@ public class CreateJobPage extends PageObject {
 	@FindBy(className = "NewJobDetails-nameInput") 														    private WebElement jobNameInput;
 	@FindBy(className = "CreateJob-placeholder")															private WebElement instructionText;
 	@FindBy(className = "ImagerySearch-loadingMask")														private WebElement loadingMask;
-	@FindBy(className = "ImagerySearch-errorMessage")														private WebElement searchErrorMessage;
+	@FindBy(className = "ImagerySearch-errorMessage")														private WebElement searchErrorBox;
 	@FindBy(className = "AlgorithmList-errorMessage")														private WebElement algorithmErrorBox;
 	@FindBy(className = "CatalogSearchCriteria-clearBbox")													private WebElement clearButton;
 	@FindBy(className = "Algorithm-startButton")															private WebElement algorithmButton;
 	@FindBy(className = "CatalogSearchCriteria-minimap")													private WebElement minimapContainer;
 	@FindBy(xpath = "//div[contains(@class, 'ImagerySearchList-results')				]/table")			private WebElement resultsTable;
 	@FindBy(xpath = "//div[contains(@class, 'AlgorithmList-errorMessage')				]/p")				private WebElement algorithmErrorMessage;
+	@FindBy(xpath = "//div[contains(@class, 'ImagerySearch-errorMessage')				]/p")				private WebElement searchErrorMessage;
 	@FindBy(xpath = "//label[contains(@class, 'CatalogSearchCriteria-apiKey')			]/child::input")	private WebElement apiKeyEntry;
 	@FindBy(xpath = "//label[contains(@class, 'CatalogSearchCriteria-captureDateFrom')	]/child::input")	private WebElement fromDateEntry;
 	@FindBy(xpath = "//label[contains(@class, 'CatalogSearchCriteria-captureDateTo')	]/child::input")	private WebElement toDateEntry;
 	@FindBy(xpath = "//label[contains(@class, 'CatalogSearchCriteria-cloudCover')		]/child::input")	private WebElement cloudSlider;
 	@FindBy(xpath = "//label[contains(@class, 'CatalogSearchCriteria-source')			]/child::select")	private WebElement sourceDropdown;
-	@FindBy(css = "button[type=submit]")																	private WebElement submitButton;
+	@FindBy(xpath = "//div[contains(@class, 'ImagerySearch-controls')]/button[contains(@type, 'submit')]")	private WebElement imagerySearchButton;
 	/* @formatter:on */
 
 	private Actions actions;
@@ -127,7 +128,7 @@ public class CreateJobPage extends PageObject {
 	 * @return Array containing two entries. The first entry is the start date, the second entry is the end date.
 	 */
 	public String[] getSearchDates() {
-		return new String[] { fromDateEntry.getText(), toDateEntry.getText() };
+		return new String[] { fromDateEntry.getAttribute("value"), toDateEntry.getAttribute("value") };
 	}
 
 	/**
@@ -154,7 +155,7 @@ public class CreateJobPage extends PageObject {
 	 * Clicks the submit button to search for imagery.
 	 */
 	public void searchForImagery() {
-		submitButton.click();
+		imagerySearchButton.click();
 	}
 
 	/**
@@ -163,7 +164,7 @@ public class CreateJobPage extends PageObject {
 	 * As an implicit assertion, searches should not exceed the duration of the wait.
 	 */
 	public void waitForSearchToComplete() {
-		WebDriverWait wait = new WebDriverWait(driver, 60);
+		WebDriverWait wait = new WebDriverWait(driver, 30);
 		wait.until(ExpectedConditions.visibilityOf(resultsTable));
 	}
 
@@ -173,7 +174,16 @@ public class CreateJobPage extends PageObject {
 	 * @return True if search is enabled, false if not
 	 */
 	public boolean isSearchEnabled() {
-		return submitButton.isEnabled();
+		return imagerySearchButton.isEnabled();
+	}
+
+	/**
+	 * Checks if the Search experienced and error and the error is displayed
+	 * 
+	 * @return True if the error box is being displayed, false if not
+	 */
+	public boolean isSearchErrorDisplayed() {
+		return searchErrorBox.isDisplayed();
 	}
 
 	/**
@@ -215,6 +225,15 @@ public class CreateJobPage extends PageObject {
 	 */
 	public String getAlgorithmErrorMessage() {
 		return algorithmErrorMessage.getText();
+	}
+
+	/**
+	 * Returns the Search error message, if it is currently being displayed
+	 * 
+	 * @return Search error message
+	 */
+	public String getImagerySearchErrorMessage() {
+		return searchErrorMessage.getText();
 	}
 
 	/**

--- a/ci/Selenium/src/test/java/bfui/test/page/CreateJobPage.java
+++ b/ci/Selenium/src/test/java/bfui/test/page/CreateJobPage.java
@@ -24,11 +24,13 @@ public class CreateJobPage extends PageObject {
 	@FindBy(className = "NewJobDetails-nameInput") 														    private WebElement jobNameInput;
 	@FindBy(className = "CreateJob-placeholder")															private WebElement instructionText;
 	@FindBy(className = "ImagerySearch-loadingMask")														private WebElement loadingMask;
-	@FindBy(className = "ImagerySearch-errorMessage")														private WebElement errorMessage;
+	@FindBy(className = "ImagerySearch-errorMessage")														private WebElement searchErrorMessage;
+	@FindBy(className = "AlgorithmList-errorMessage")														private WebElement algorithmErrorBox;
 	@FindBy(className = "CatalogSearchCriteria-clearBbox")													private WebElement clearButton;
 	@FindBy(className = "Algorithm-startButton")															private WebElement algorithmButton;
 	@FindBy(className = "CatalogSearchCriteria-minimap")													private WebElement minimapContainer;
 	@FindBy(xpath = "//div[contains(@class, 'ImagerySearchList-results')				]/table")			private WebElement resultsTable;
+	@FindBy(xpath = "//div[contains(@class, 'AlgorithmList-errorMessage')				]/p")				private WebElement algorithmErrorMessage;
 	@FindBy(xpath = "//label[contains(@class, 'CatalogSearchCriteria-apiKey')			]/child::input")	private WebElement apiKeyEntry;
 	@FindBy(xpath = "//label[contains(@class, 'CatalogSearchCriteria-captureDateFrom')	]/child::input")	private WebElement fromDateEntry;
 	@FindBy(xpath = "//label[contains(@class, 'CatalogSearchCriteria-captureDateTo')	]/child::input")	private WebElement toDateEntry;
@@ -161,7 +163,7 @@ public class CreateJobPage extends PageObject {
 	 * As an implicit assertion, searches should not exceed the duration of the wait.
 	 */
 	public void waitForSearchToComplete() {
-		WebDriverWait wait = new WebDriverWait(driver, 15);
+		WebDriverWait wait = new WebDriverWait(driver, 60);
 		wait.until(ExpectedConditions.visibilityOf(resultsTable));
 	}
 
@@ -195,6 +197,24 @@ public class CreateJobPage extends PageObject {
 	 */
 	public boolean isSearching() {
 		return loadingMask.isDisplayed();
+	}
+
+	/**
+	 * Checks if the algorithm error is currently displayed
+	 * 
+	 * @return True if the error is displayed, false if not
+	 */
+	public boolean isAlgorithmErrorDisplayed() {
+		return algorithmErrorBox.isDisplayed();
+	}
+
+	/**
+	 * Returns the Algorithm error message, if it is currently being displayed
+	 * 
+	 * @return The algorithm error
+	 */
+	public String getAlgorithmErrorMessage() {
+		return algorithmErrorMessage.getText();
 	}
 
 	/**

--- a/ci/Selenium/src/test/java/bfui/test/util/Utils.java
+++ b/ci/Selenium/src/test/java/bfui/test/util/Utils.java
@@ -56,10 +56,8 @@ public class Utils {
 		options.addArguments("--ignore-certificate-errors");
 		options.setCapability("acceptInsecureCerts", true);
 		options.setCapability("acceptSslCerts", true);
-		options.setCapability("acceptInsecureCerts", true);
 		options.setCapability("commandTimeout", "600");
 		options.setCapability("idleTimeout", "1000");
-		options.setCapability("screenResolution", "1920x1080");
 		RemoteWebDriver driver = new RemoteWebDriver(new URL(gridUrl), options);
 		return driver;
 	}


### PR DESCRIPTION
This adds the Planet data sources to the Selenium tests. They are optional, and are driven by the presence of two environment variables.

These variables will not be injected in the pipelines for now, since the keys appear to be very intermittently functional. As a result, I've tried to insert as many helpful error-catching measures in the code as possible. 